### PR TITLE
24 tweets model use db

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -1,6 +1,9 @@
 {
   "name": "conf-twitter-bot-server",
   "version": "0.0.1",
+  "engines": {
+    "node": ">=16.0.0"
+  },
   "description": "CS Conference Twitter Bot Server",
   "author": {
     "name": "Stefan Marr",

--- a/backend/prisma/migrations/20220916104556_/migration.sql
+++ b/backend/prisma/migrations/20220916104556_/migration.sql
@@ -1,0 +1,8 @@
+/*
+  Warnings:
+
+  - Added the required column `scheduledTimeUTC` to the `Tweet` table without a default value. This is not possible if the table is not empty.
+
+*/
+-- AlterTable
+ALTER TABLE "Tweet" ADD COLUMN     "scheduledTimeUTC" TIMESTAMPTZ(3) NOT NULL;

--- a/backend/prisma/migrations/20220917152709_test/migration.sql
+++ b/backend/prisma/migrations/20220917152709_test/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "Tweet" ALTER COLUMN "updatedAt" DROP NOT NULL;

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -49,15 +49,16 @@ model TwitterUser {
 }
 
 model Tweet {
-    id            Int         @id @default(autoincrement())
-    account       Account     @relation(fields: [accountId], references: [id])
-    accountId     Int
-    twitterUser   TwitterUser @relation(fields: [twitterUserId], references: [id])
-    twitterUserId BigInt
-    createdAt     DateTime    @default(now())
-    updatedAt     DateTime
-    content       String      @db.VarChar(280)
-    sent          Boolean     @default(false)
+    id               Int         @id @default(autoincrement())
+    account          Account     @relation(fields: [accountId], references: [id])
+    accountId        Int
+    twitterUser      TwitterUser @relation(fields: [twitterUserId], references: [id])
+    twitterUserId    BigInt
+    createdAt        DateTime    @default(now())
+    updatedAt        DateTime
+    scheduledTimeUTC DateTime    @db.Timestamptz(3)
+    content          String      @db.VarChar(280)
+    sent             Boolean     @default(false)
 }
 
 model TwitterOAuth {

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -7,7 +7,7 @@ generator client {
 
 datasource db {
     provider = "postgresql"
-    url      = env("DATABASE_URL")
+    url      = env("DATABASE_URL") // "postgresql://postgres:postgres@localhost:5400/ConfTwitterBot"
 }
 
 model User {
@@ -55,7 +55,7 @@ model Tweet {
     twitterUser      TwitterUser @relation(fields: [twitterUserId], references: [id])
     twitterUserId    BigInt
     createdAt        DateTime    @default(now())
-    updatedAt        DateTime
+    updatedAt        DateTime?
     scheduledTimeUTC DateTime    @db.Timestamptz(3)
     content          String      @db.VarChar(280)
     sent             Boolean     @default(false)

--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -30,6 +30,11 @@ app.keys = ['Session Key Secret 5346fdg434'];
 app.proxy = true;
 app.use(koaSession(SESSION_CONFIG, app));
 
+// fix for: TypeError: Do not know how to serialize a BigInt
+(BigInt.prototype as any).toJSON = function () {
+	return this.toString();
+};
+
 app.use(async (ctx, next) => {
 	try {
 		await next();

--- a/backend/src/routes/tweets/tweets-controller.ts
+++ b/backend/src/routes/tweets/tweets-controller.ts
@@ -1,12 +1,8 @@
 import { ParameterizedContext } from 'koa';
 import HttpStatus from 'http-status';
 import { getTweets, insertTweet } from './tweets-model';
-
-interface HTTPTweet {
-	userId: string;
-	text: string;
-	scheduledTimeUTC?: string;
-}
+import { ServerError } from '../types';
+import { HTTPTweet } from './tweets';
 
 export const tweets = async (ctx: ParameterizedContext): Promise<void> => {
 	const tweets = getTweets();
@@ -27,10 +23,11 @@ export const sentTweets = async (ctx: ParameterizedContext): Promise<void> => {
 
 export const createTweet = async (ctx: ParameterizedContext): Promise<void> => {
 	const httpTweet: HTTPTweet = ctx.request.body;
+	const result = await insertTweet(httpTweet);
 
-	// failed to insert tweet
-	if (!insertTweet(httpTweet)) {
-		ctx.status = HttpStatus.UNAUTHORIZED;
+	if (result instanceof ServerError) {
+		ctx.status = result.getStatusCode();
+		ctx.body = { message: result.getMessage() };
 		return;
 	}
 

--- a/backend/src/routes/tweets/tweets-controller.ts
+++ b/backend/src/routes/tweets/tweets-controller.ts
@@ -5,7 +5,7 @@ import { ServerError } from '../types';
 import { HTTPTweet } from './tweets';
 
 export const tweets = async (ctx: ParameterizedContext): Promise<void> => {
-	const tweets = getTweets();
+	const tweets = await getTweets(ctx.session.userId);
 
 	ctx.status = HttpStatus.OK;
 	ctx.body = tweets;

--- a/backend/src/routes/tweets/tweets-model.ts
+++ b/backend/src/routes/tweets/tweets-model.ts
@@ -1,8 +1,10 @@
 /**
  * Model for creating/reading/updating/deleting stored tweets
  */
+import HttpStatus from 'http-status';
 import { HTTPTweet, Tweets } from './tweets';
 import prisma from '../../../lib/prisma';
+import { ServerError } from '../types';
 
 let tweets: Tweets;
 
@@ -32,32 +34,59 @@ export const getAllTweets = async (twitterUserId: string): Promise<void> => {
 	console.log(result);
 };
 
-export const insertTweet = (httpTweet: HTTPTweet): boolean => {
-	const { text, userId, scheduledTimeUTC } = httpTweet;
+export const insertTweet = async (httpTweet: HTTPTweet): Promise<boolean | ServerError> => {
+	const { accountId, twitterUserId, scheduledTimeUTC, content } = httpTweet;
 
 	// temp, need a better check
-	if (userId.length === 0 || text.length === 0 || scheduledTimeUTC.length === 0) {
-		return false;
+	if (accountId.length === 0 || twitterUserId.length === 0 || scheduledTimeUTC.length === 0 || content.length === 0) {
+		return new ServerError(HttpStatus.UNAUTHORIZED, 'Tweet missing required fields.');
 	}
 
-	// temp, convert httpTweet to regular tweet
-	const tweet = {
-		text,
-		image64: '',
-		paperId: 0,
-		userId,
-		scheduledTimeUTC,
-	};
-
-	// temp until a real database is implemented, load data
-	tweets = getTweets();
-	// tweets.push(tweet);
+	const isoDate = new Date(scheduledTimeUTC);
 
 	try {
-		// writeFileSync(pathToFile, JSON.stringify(tweets));
-		return true;
+		await prisma.tweet.create({
+			data: {
+				accountId: +accountId,
+				twitterUserId: BigInt(twitterUserId),
+				scheduledTimeUTC: isoDate,
+				content,
+			},
+		});
 	} catch (e) {
-		console.log(e);
-		return false;
+		return new ServerError(HttpStatus.INTERNAL_SERVER_ERROR, 'Unable to create account due to server problem.');
 	}
+
+	// successfully inserted
+	return true;
 };
+
+// export const insertTweet = (httpTweet: HTTPTweet): boolean => {
+// 	const { text, userId, scheduledTimeUTC } = httpTweet;
+//
+// 	// temp, need a better check
+// 	if (userId.length === 0 || text.length === 0 || scheduledTimeUTC.length === 0) {
+// 		return false;
+// 	}
+//
+// 	// temp, convert httpTweet to regular tweet
+// 	const tweet = {
+// 		text,
+// 		image64: '',
+// 		paperId: 0,
+// 		userId,
+// 		scheduledTimeUTC,
+// 	};
+//
+// 	// temp until a real database is implemented, load data
+// 	tweets = getTweets();
+// 	// tweets.push(tweet);
+//
+// 	try {
+// 		// writeFileSync(pathToFile, JSON.stringify(tweets));
+// 		return true;
+// 	} catch (e) {
+// 		console.log(e);
+// 		return false;
+// 	}
+// };

--- a/backend/src/routes/tweets/tweets-model.ts
+++ b/backend/src/routes/tweets/tweets-model.ts
@@ -46,33 +46,3 @@ export const insertTweet = async (httpTweet: HTTPTweet): Promise<boolean | Serve
 	// successfully inserted
 	return true;
 };
-
-// export const insertTweet = (httpTweet: HTTPTweet): boolean => {
-// 	const { text, userId, scheduledTimeUTC } = httpTweet;
-//
-// 	// temp, need a better check
-// 	if (userId.length === 0 || text.length === 0 || scheduledTimeUTC.length === 0) {
-// 		return false;
-// 	}
-//
-// 	// temp, convert httpTweet to regular tweet
-// 	const tweet = {
-// 		text,
-// 		image64: '',
-// 		paperId: 0,
-// 		userId,
-// 		scheduledTimeUTC,
-// 	};
-//
-// 	// temp until a real database is implemented, load data
-// 	tweets = getTweets();
-// 	// tweets.push(tweet);
-//
-// 	try {
-// 		// writeFileSync(pathToFile, JSON.stringify(tweets));
-// 		return true;
-// 	} catch (e) {
-// 		console.log(e);
-// 		return false;
-// 	}
-// };

--- a/backend/src/routes/tweets/tweets-model.ts
+++ b/backend/src/routes/tweets/tweets-model.ts
@@ -6,20 +6,8 @@ import { HTTPTweet, Tweets } from './tweets';
 import prisma from '../../../lib/prisma';
 import { ServerError } from '../types';
 
-let tweets: Tweets;
-
-export const getTweets = (): Tweets =>
-	// try {
-	// 	const fileContent = readFileSync(pathToFile).toString();
-	// 	tweets = <Tweets>JSON.parse(fileContent);
-	// } catch (e) {
-	// 	console.error(e);
-	// 	tweets = [];
-	// }
-	tweets;
-
-export const getAllTweets = async (twitterUserId: string): Promise<void> => {
-	const result = prisma.tweet.findMany({
+export const getTweets = async (twitterUserId: string): Promise<Tweets> =>
+	prisma.tweet.findMany({
 		where: {
 			twitterUserId: BigInt(twitterUserId),
 		},
@@ -31,8 +19,6 @@ export const getAllTweets = async (twitterUserId: string): Promise<void> => {
 			sent: true,
 		},
 	});
-	console.log(result);
-};
 
 export const insertTweet = async (httpTweet: HTTPTweet): Promise<boolean | ServerError> => {
 	const { accountId, twitterUserId, scheduledTimeUTC, content } = httpTweet;

--- a/backend/src/routes/tweets/tweets-model.ts
+++ b/backend/src/routes/tweets/tweets-model.ts
@@ -1,23 +1,35 @@
 /**
  * Model for creating/reading/updating/deleting stored tweets
- * TODO: Convert from JSON store to DB Object
  */
-import path from 'path';
-import { readFileSync, writeFileSync } from 'fs';
 import { HTTPTweet, Tweets } from './tweets';
+import prisma from '../../../lib/prisma';
 
 let tweets: Tweets;
-const pathToFile = path.relative(process.cwd(), 'data/tweets.json');
 
-export const getTweets = (): Tweets => {
-	try {
-		const fileContent = readFileSync(pathToFile).toString();
-		tweets = <Tweets>JSON.parse(fileContent);
-	} catch (e) {
-		console.error(e);
-		tweets = [];
-	}
-	return tweets;
+export const getTweets = (): Tweets =>
+	// try {
+	// 	const fileContent = readFileSync(pathToFile).toString();
+	// 	tweets = <Tweets>JSON.parse(fileContent);
+	// } catch (e) {
+	// 	console.error(e);
+	// 	tweets = [];
+	// }
+	tweets;
+
+export const getAllTweets = async (twitterUserId: string): Promise<void> => {
+	const result = prisma.tweet.findMany({
+		where: {
+			twitterUserId: BigInt(twitterUserId),
+		},
+		select: {
+			id: true,
+			twitterUserId: true,
+			scheduledTimeUTC: true,
+			content: true,
+			sent: true,
+		},
+	});
+	console.log(result);
 };
 
 export const insertTweet = (httpTweet: HTTPTweet): boolean => {
@@ -39,10 +51,10 @@ export const insertTweet = (httpTweet: HTTPTweet): boolean => {
 
 	// temp until a real database is implemented, load data
 	tweets = getTweets();
-	tweets.push(tweet);
+	// tweets.push(tweet);
 
 	try {
-		writeFileSync(pathToFile, JSON.stringify(tweets));
+		// writeFileSync(pathToFile, JSON.stringify(tweets));
 		return true;
 	} catch (e) {
 		console.log(e);

--- a/backend/src/routes/tweets/tweets.d.ts
+++ b/backend/src/routes/tweets/tweets.d.ts
@@ -1,5 +1,5 @@
 // Single Tweet
-export interface Tweet {
+export interface OldTweet {
 	id?: number;
 	text: string;
 	image64: string;
@@ -7,6 +7,14 @@ export interface Tweet {
 	userId?: string;
 	scheduledTimeUTC?: string;
 	sent?: boolean;
+}
+
+export interface Tweet {
+	id: number;
+	twitterUserId: string;
+	scheduledTimeUTC: string;
+	content: string;
+	sent: boolean;
 }
 
 // Tweet sent from frontend and received by backend

--- a/backend/src/routes/tweets/tweets.d.ts
+++ b/backend/src/routes/tweets/tweets.d.ts
@@ -1,14 +1,4 @@
 // Single Tweet
-export interface OldTweet {
-	id?: number;
-	text: string;
-	image64: string;
-	paperId: number;
-	userId?: string;
-	scheduledTimeUTC?: string;
-	sent?: boolean;
-}
-
 export interface Tweet {
 	id: number;
 	twitterUserId: bigint;

--- a/backend/src/routes/tweets/tweets.d.ts
+++ b/backend/src/routes/tweets/tweets.d.ts
@@ -19,9 +19,10 @@ export interface Tweet {
 
 // Tweet sent from frontend and received by backend
 export interface HTTPTweet {
-	userId: string;
-	text: string;
+	accountId: string;
+	twitterUserId: string;
 	scheduledTimeUTC?: string;
+	content: string;
 }
 
 // Array of Tweets

--- a/backend/src/routes/tweets/tweets.d.ts
+++ b/backend/src/routes/tweets/tweets.d.ts
@@ -11,8 +11,8 @@ export interface OldTweet {
 
 export interface Tweet {
 	id: number;
-	twitterUserId: string;
-	scheduledTimeUTC: string;
+	twitterUserId: bigint;
+	scheduledTimeUTC: Date | string;
 	content: string;
 	sent: boolean;
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,7 +48,7 @@ services:
             dockerfile: Dockerfile.dev
             context: ./backend
         environment:
-            - DATABASE_URL=postgresql://postgres:postgres@postgres:5400/ConfTwitterBot
+            - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/ConfTwitterBot
         volumes:
             - /app/node_modules
             - ./backend:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,7 +6,7 @@ services:
         restart: unless-stopped
         hostname: postgres
         ports:
-            - "5432:5432"
+            - "5400:5432"
         environment:
             POSTGRES_USER: postgres
             POSTGRES_PASSWORD: postgres
@@ -48,7 +48,7 @@ services:
             dockerfile: Dockerfile.dev
             context: ./backend
         environment:
-            - DATABASE_URL=postgresql://postgres:postgres@postgres:5432/ConfTwitterBot
+            - DATABASE_URL=postgresql://postgres:postgres@postgres:5400/ConfTwitterBot
         volumes:
             - /app/node_modules
             - ./backend:/app

--- a/frontend/src/components/ui/TweetBox.tsx
+++ b/frontend/src/components/ui/TweetBox.tsx
@@ -52,9 +52,10 @@ const TweetBox = () => {
 	const postTweet = async (): Promise<void> => {
 		try {
 			const payload = {
-				userId: activeAccount.userId,
-				text: tweetText,
+				accountId: 1,
+				twitterUserId: activeAccount.userId,
 				scheduledTimeUTC: dateTimeISO,
+				content: tweetText,
 			};
 			const response = await axios.post('/api/tweets', payload);
 			if (response.status === HttpStatus.CREATED) {

--- a/frontend/src/pages/Dashboard/tweets/AllTweets.tsx
+++ b/frontend/src/pages/Dashboard/tweets/AllTweets.tsx
@@ -26,7 +26,7 @@ const AllTweets = () => {
 		return (
 			<div key={index} className="border-b border-slate-200 pb-4">
 				<small>{tweetDate}</small>
-				<p>{tweet.text}</p>
+				<p>{tweet.content}</p>
 			</div>
 		);
 	});

--- a/frontend/src/pages/Dashboard/tweets/AllTweets.tsx
+++ b/frontend/src/pages/Dashboard/tweets/AllTweets.tsx
@@ -7,10 +7,8 @@ const AllTweets = () => {
 	const [tweets, setTweets] = useState<Tweets>([]);
 
 	useEffect(() => {
-		if (tweets.length === 0) {
-			getTweets().then();
-		}
-	}, [tweets]);
+		getTweets().then();
+	}, []);
 
 	const getTweets = async () => {
 		try {
@@ -31,7 +29,7 @@ const AllTweets = () => {
 		);
 	});
 
-	return <div className="grid gap-4">{displayTweets}</div>;
+	return <>{tweets.length > 0 ? <div className="grid gap-4">{displayTweets}</div> : <p>No tweets to display.</p>}</>;
 };
 
 export default AllTweets;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -14,14 +14,22 @@ export interface ActiveTwitterAccountContext {
 export type TwitterAccounts = Array<TwitterAccount>;
 
 // Single Tweet
+// export interface Tweet {
+// 	id?: number;
+// 	text: string;
+// 	image64: string;
+// 	paperId: number;
+// 	userId?: string;
+// 	scheduledTimeUTC?: string;
+// 	sent?: boolean;
+// }
+
 export interface Tweet {
-	id?: number;
-	text: string;
-	image64: string;
-	paperId: number;
-	userId?: string;
-	scheduledTimeUTC?: string;
-	sent?: boolean;
+	id: number;
+	twitterUserId: bigint;
+	scheduledTimeUTC: Date | string;
+	content: string;
+	sent: boolean;
 }
 
 // Array of Tweets


### PR DESCRIPTION
Closes #24.

Tweets are now read/created using Prisma however, requires #21 to be implemented since tweet insertion relies on accountId foreign key. This can be bypassed for now by manually adding rows.