### PR TITLE
Additional route unit tests

### DIFF
--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -58,6 +58,7 @@ module.exports = {
 		'quotes': [2, 'single', { 'avoidEscape': true, 'allowTemplateLiterals': true }],
 		'no-use-before-define': ['error', {"functions": false, "classes": false}],
 		'@typescript-eslint/no-shadow': 'off',
+		'@typescript-eslint/ban-ts-comment': 'off',
 		'@typescript-eslint/no-explicit-any': 'off',
 		'@typescript-eslint/indent': ['error', 'tab'],
 		'@typescript-eslint/no-unused-vars': ['error', { 'argsIgnorePattern': '^_' }],

--- a/backend/src/routes/sessions/__tests__/sessions-model.test.ts
+++ b/backend/src/routes/sessions/__tests__/sessions-model.test.ts
@@ -1,0 +1,37 @@
+import { validSessionCookie } from '../sessions-model';
+
+test('valid session cookie should return true', async () => {
+	const requestCookie =
+		// eslint-disable-next-line max-len
+		'ConfTwBot=some_random_hash_string==; ConfTwBot.sig=not_real_sig';
+	const sessionCookie = 'ConfTwBot=some_random_hash_string==';
+
+	expect(validSessionCookie(requestCookie, sessionCookie)).toEqual(true);
+});
+
+test('invalid cookie name should return false', async () => {
+	const requestCookie =
+		// eslint-disable-next-line max-len
+		'LameBot=some_random_hash_string==; LameBot.sig=not_real_sig';
+	const sessionCookie = 'ConfTwBot=some_random_hash_string==';
+
+	expect(validSessionCookie(requestCookie, sessionCookie)).toEqual(false);
+});
+
+test('invalid cookie length should return false', async () => {
+	const requestCookie =
+		// eslint-disable-next-line max-len
+		'ConfTwBot=; ConfTwBot.sig=';
+	const sessionCookie = 'ConfTwBot=some_random_hash_string';
+
+	expect(validSessionCookie(requestCookie, sessionCookie)).toEqual(false);
+});
+
+test('request and session cookie mismatching value should return false', async () => {
+	const requestCookie =
+		// eslint-disable-next-line max-len
+		'ConfTwBot=some_value==; ConfTwBot.sig=not_real_sig';
+	const sessionCookie = 'ConfTwBot=a_different_value==';
+
+	expect(validSessionCookie(requestCookie, sessionCookie)).toEqual(false);
+});

--- a/backend/src/routes/sessions/sessions-model.ts
+++ b/backend/src/routes/sessions/sessions-model.ts
@@ -7,7 +7,6 @@ import prisma from '../../../lib/prisma';
 export const validSessionCookie = (requestCookie: string, sessionCookie: string): boolean => {
 	if (requestCookie && requestCookie.length > 0) {
 		// extract the ConfTwBot cookie (request may contain many cookies)
-		// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 		// @ts-ignore
 		const confTwBotCookie = requestCookie.split('; ConfTwBot=').pop().split(';')[0];
 		// if the confTwBot cookie is missing, then the variable will contain an empty string

--- a/backend/src/routes/sessions/sessions-model.ts
+++ b/backend/src/routes/sessions/sessions-model.ts
@@ -1,6 +1,5 @@
 import HttpStatus from 'http-status';
 import bcrypt from 'bcryptjs';
-import { userExists } from '../users/users-model';
 import { ServerError } from '../types';
 import prisma from '../../../lib/prisma';
 

--- a/backend/src/routes/sessions/sessions-model.ts
+++ b/backend/src/routes/sessions/sessions-model.ts
@@ -22,11 +22,6 @@ export const validSessionCookie = (requestCookie: string, sessionCookie: string)
 
 // return user id if login successful, otherwise return error
 export const validUserLogin = async (username: string, plainTextPassword: string): Promise<number | ServerError> => {
-	// check to see if an account with that username exists before trying password
-	if (!(await userExists(username))) {
-		return new ServerError(HttpStatus.NOT_FOUND, 'Sorry, an account with that username does not exist.');
-	}
-
 	// get password hash for provided username
 	const result = await prisma.user.findUnique({
 		where: {
@@ -40,7 +35,7 @@ export const validUserLogin = async (username: string, plainTextPassword: string
 
 	// extract password from result and rename to hash
 	if (result === null) {
-		return new ServerError(HttpStatus.UNAUTHORIZED, 'Account does not exist.');
+		return new ServerError(HttpStatus.UNAUTHORIZED, 'Invalid username or password.');
 	}
 
 	const { id: userId, password: hash } = result;

--- a/backend/src/routes/tweets/__tests__/tweets-model.test.ts
+++ b/backend/src/routes/tweets/__tests__/tweets-model.test.ts
@@ -1,0 +1,50 @@
+import HttpStatus from 'http-status';
+import { prismaMock } from '../../../../lib/prismaMock';
+import { insertTweet } from '../tweets-model';
+import { HTTPTweet } from '../tweets';
+import { ServerError } from '../../types';
+
+const tweet = {
+	id: 1,
+	accountId: 1,
+	twitterUserId: BigInt(1),
+	scheduledTimeUTC: new Date().toUTCString(),
+	content: 'My test tweet',
+	sent: false,
+	createdAt: new Date(),
+	updatedAt: null,
+};
+
+test('should insert new tweet', async () => {
+	// prisma keeps saying "date" is a string, must be a bug as I'm clearly doing "new Date():
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	prismaMock.tweet.create.mockResolvedValue(tweet);
+
+	const newTweet: HTTPTweet = {
+		accountId: '1',
+		twitterUserId: tweet.twitterUserId.toString(),
+		scheduledTimeUTC: tweet.scheduledTimeUTC.toString(),
+		content: tweet.content,
+	};
+
+	await expect(insertTweet(newTweet)).resolves.toEqual(true);
+});
+
+test('insert tweet should return unauthorised error', async () => {
+	// prisma keeps saying "date" is a string, must be a bug as I'm clearly doing "new Date():
+	// eslint-disable-next-line @typescript-eslint/ban-ts-comment
+	// @ts-ignore
+	prismaMock.tweet.create.mockResolvedValue(tweet);
+
+	const newTweet: HTTPTweet = {
+		accountId: '',
+		twitterUserId: '',
+		scheduledTimeUTC: '',
+		content: '',
+	};
+
+	await expect(insertTweet(newTweet)).resolves.toEqual(
+		new ServerError(HttpStatus.UNAUTHORIZED, 'Tweet missing required fields.'),
+	);
+});

--- a/backend/src/routes/twitter-users/__tests__/twitter-users-model.test.ts
+++ b/backend/src/routes/twitter-users/__tests__/twitter-users-model.test.ts
@@ -1,0 +1,37 @@
+import { prismaMock } from '../../../../lib/prismaMock';
+import { getTwitterUser, insertTwitterUser } from '../twitter-users-model';
+import { TwitterAccount } from '../../oauths/oauths';
+import { TwitterUser } from '../../accounts/accounts';
+
+const twitterUser: TwitterUser = {
+	id: BigInt(1),
+	name: 'test_account',
+	screenName: 'Test Account',
+	profileImageUrl: 'image.png',
+};
+
+const twitterAccount: TwitterAccount = {
+	userId: twitterUser.id.toString(),
+	name: twitterUser.name,
+	screenName: twitterUser.screenName,
+	profileImageUrl: twitterUser.profileImageUrl,
+	oauth: {},
+};
+
+test('should create twitter user', async () => {
+	prismaMock.twitterUser.create.mockResolvedValue(twitterUser);
+
+	await expect(insertTwitterUser(twitterAccount)).resolves.toEqual(twitterUser.id);
+});
+
+test('get twitter user should return twitter user', async () => {
+	prismaMock.twitterUser.findUnique.mockResolvedValue(twitterUser);
+
+	await expect(getTwitterUser(twitterAccount.userId)).resolves.toEqual(twitterUser);
+});
+
+test('get twitter user should return null', async () => {
+	prismaMock.twitterUser.findUnique.mockResolvedValue(null);
+
+	await expect(getTwitterUser(twitterAccount.userId)).resolves.toEqual(null);
+});


### PR DESCRIPTION
Unit tests for sessions model, tweets model and twitter users model.

Disabled 'ban-ts-comment' rule so writing 'ts-ignore' will no longer throw an error; I did this as there are some type errors that cannot be fixed or are not worth fixing.