### PR TITLE
Grid/List toggle

### DIFF
--- a/frontend/src/components/ui/DarkModeButton.tsx
+++ b/frontend/src/components/ui/DarkModeButton.tsx
@@ -14,7 +14,6 @@ const DarkModeButton = () => {
 			document.documentElement.classList.add('dark');
 			setIcon(<IconSun />);
 		}
-		console.log('useEffect: ' + colorMode);
 	}, [colorMode]);
 
 	const handleClick = (e: React.MouseEvent<HTMLButtonElement>) => {

--- a/frontend/src/features/dashboard/components/Content.tsx
+++ b/frontend/src/features/dashboard/components/Content.tsx
@@ -27,11 +27,11 @@ const Content = ({ active }: Props) => {
 			<h2 className="text-xl font-bold mb-8">Dashboard</h2>
 			<CreateTweet />
 			<hr className="my-8" />
-			<div className="flex items-center gap-6">
+			<div className="flex items-center justify-between gap-6">
 				<h2 className="text-xl font-bold mb-4">{active.title}</h2>
 				{active.title !== '' && (
 					<div className="pb-3">
-						<ToggleListGrid handleClick={handleClick} />
+						<ToggleListGrid isList={isList} handleClick={handleClick} />
 					</div>
 				)}
 			</div>

--- a/frontend/src/features/dashboard/components/Content.tsx
+++ b/frontend/src/features/dashboard/components/Content.tsx
@@ -1,6 +1,7 @@
 import CreateTweet from '../../tweets/components/CreateTweet';
 import TweetsList from '../../tweets/components/TweetsList';
 import PapersList from '../../papers/components/PapersList';
+import ToggleListGrid from './toggleListGrid';
 
 interface Props {
 	active: { index: number; title: string };
@@ -12,7 +13,14 @@ const Content = ({ active }: Props) => {
 			<h2 className="text-xl font-bold mb-8">Dashboard</h2>
 			<CreateTweet />
 			<hr className="my-8" />
-			<h2 className="text-xl font-bold mb-4">{active.title}</h2>
+			<div className="flex items-center gap-6">
+				<h2 className="text-xl font-bold mb-4">{active.title}</h2>
+				{active.title !== '' && (
+					<div className="pb-3">
+						<ToggleListGrid />
+					</div>
+				)}
+			</div>
 			{active.title === 'Tweets' && <TweetsList />}
 			{active.title === 'Papers' && <PapersList />}
 		</div>

--- a/frontend/src/features/dashboard/components/Content.tsx
+++ b/frontend/src/features/dashboard/components/Content.tsx
@@ -1,5 +1,5 @@
 import CreateTweet from '../../tweets/components/CreateTweet';
-import TweetsList from '../../tweets/components/TweetsList';
+import Tweets from '../../tweets/components/Tweets';
 import PapersList from '../../papers/components/PapersList';
 import ToggleListGrid from './toggleListGrid';
 import { useState } from 'react';
@@ -35,7 +35,7 @@ const Content = ({ active }: Props) => {
 					</div>
 				)}
 			</div>
-			{active.title === 'Tweets' && <TweetsList />}
+			{active.title === 'Tweets' && <Tweets isList={isList} />}
 			{active.title === 'Papers' && <PapersList />}
 		</div>
 	);

--- a/frontend/src/features/dashboard/components/Content.tsx
+++ b/frontend/src/features/dashboard/components/Content.tsx
@@ -2,12 +2,26 @@ import CreateTweet from '../../tweets/components/CreateTweet';
 import TweetsList from '../../tweets/components/TweetsList';
 import PapersList from '../../papers/components/PapersList';
 import ToggleListGrid from './toggleListGrid';
+import { useState } from 'react';
 
 interface Props {
 	active: { index: number; title: string };
 }
 
 const Content = ({ active }: Props) => {
+	const [isList, setListActive] = useState({
+		activeLayout: 'list',
+	});
+
+	const handleClick = (e: React.MouseEvent<HTMLButtonElement>, name: string) => {
+		e.preventDefault();
+		if (isList.activeLayout !== name) {
+			setListActive({
+				activeLayout: name,
+			});
+		}
+	};
+
 	return (
 		<div className="col-span-8">
 			<h2 className="text-xl font-bold mb-8">Dashboard</h2>
@@ -17,7 +31,7 @@ const Content = ({ active }: Props) => {
 				<h2 className="text-xl font-bold mb-4">{active.title}</h2>
 				{active.title !== '' && (
 					<div className="pb-3">
-						<ToggleListGrid />
+						<ToggleListGrid handleClick={handleClick} />
 					</div>
 				)}
 			</div>

--- a/frontend/src/features/dashboard/components/Content.tsx
+++ b/frontend/src/features/dashboard/components/Content.tsx
@@ -1,6 +1,6 @@
 import CreateTweet from '../../tweets/components/CreateTweet';
 import Tweets from '../../tweets/components/Tweets';
-import PapersList from '../../papers/components/PapersList';
+import Papers from '../../papers/components/Papers';
 import ToggleListGrid from './toggleListGrid';
 import { useState } from 'react';
 
@@ -36,7 +36,7 @@ const Content = ({ active }: Props) => {
 				)}
 			</div>
 			{active.title === 'Tweets' && <Tweets isList={isList} />}
-			{active.title === 'Papers' && <PapersList />}
+			{active.title === 'Papers' && <Papers isList={isList} />}
 		</div>
 	);
 };

--- a/frontend/src/features/dashboard/components/toggleListGrid.tsx
+++ b/frontend/src/features/dashboard/components/toggleListGrid.tsx
@@ -2,43 +2,18 @@ import { Button, Stack } from '@chakra-ui/react';
 import { IconList, IconLayoutGrid } from '@tabler/icons';
 import React, { useEffect, useState } from 'react';
 
-const ToggleListGrid = () => {
-	const [isList, setListActive] = useState(true);
-	const [isGrid, setGridActive] = useState(false);
+interface Props {
+	handleClick: (e: React.MouseEvent<HTMLButtonElement>, name: string) => void;
+}
 
-	useEffect(() => {
-		if (isList === true) {
-			//set List button as active color
-			console.log('active: list');
-		} else {
-			//set Grid button as active color
-			console.log('active: grid');
-		}
-	}, [isList, isGrid]);
-
-	const handleListClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-		e.preventDefault();
-		if (!isList) {
-			setListActive(true);
-			setGridActive(false);
-		}
-	};
-
-	const handleGridClick = (e: React.MouseEvent<HTMLButtonElement>) => {
-		e.preventDefault();
-		if (!isGrid) {
-			setGridActive(true);
-			setListActive(false);
-		}
-	};
-
+const ToggleListGrid = ({ handleClick }: Props) => {
 	return (
 		<>
 			<Stack spacing={4} direction="row" align="center">
-				<Button variant="outline" size="sm" onClick={(e) => handleListClick(e)}>
+				<Button variant="outline" size="sm" onClick={(e) => handleClick(e, 'list')}>
 					{<IconList />}
 				</Button>
-				<Button variant="outline" size="sm" onClick={(e) => handleGridClick(e)}>
+				<Button variant="outline" size="sm" onClick={(e) => handleClick(e, 'grid')}>
 					{<IconLayoutGrid />}
 				</Button>
 			</Stack>

--- a/frontend/src/features/dashboard/components/toggleListGrid.tsx
+++ b/frontend/src/features/dashboard/components/toggleListGrid.tsx
@@ -1,0 +1,49 @@
+import { Button, Stack } from '@chakra-ui/react';
+import { IconList, IconLayoutGrid } from '@tabler/icons';
+import React, { useEffect, useState } from 'react';
+
+const ToggleListGrid = () => {
+	const [isList, setListActive] = useState(true);
+	const [isGrid, setGridActive] = useState(false);
+
+	useEffect(() => {
+		if (isList === true) {
+			//set List button as active color
+			console.log('active: list');
+		} else {
+			//set Grid button as active color
+			console.log('active: grid');
+		}
+	}, [isList, isGrid]);
+
+	const handleListClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+		e.preventDefault();
+		if (!isList) {
+			setListActive(true);
+			setGridActive(false);
+		}
+	};
+
+	const handleGridClick = (e: React.MouseEvent<HTMLButtonElement>) => {
+		e.preventDefault();
+		if (!isGrid) {
+			setGridActive(true);
+			setListActive(false);
+		}
+	};
+
+	return (
+		<>
+			<Stack spacing={4} direction="row" align="center">
+				<Button variant="outline" size="sm" onClick={(e) => handleListClick(e)}>
+					{<IconList />}
+				</Button>
+				<Button variant="outline" size="sm" onClick={(e) => handleGridClick(e)}>
+					{<IconLayoutGrid />}
+				</Button>
+			</Stack>
+		</>
+	);
+};
+
+export default ToggleListGrid;

--- a/frontend/src/features/dashboard/components/toggleListGrid.tsx
+++ b/frontend/src/features/dashboard/components/toggleListGrid.tsx
@@ -1,18 +1,29 @@
-import { Button, Stack } from '@chakra-ui/react';
+import { Button, css, Stack } from '@chakra-ui/react';
 import { IconList, IconLayoutGrid } from '@tabler/icons';
 
 interface Props {
 	handleClick: (e: React.MouseEvent<HTMLButtonElement>, name: string) => void;
+	isList: { activeLayout: string };
 }
 
-const ToggleListGrid = ({ handleClick }: Props) => {
+const ToggleListGrid = ({ handleClick, isList }: Props) => {
 	return (
 		<>
 			<Stack spacing={4} direction="row" align="center">
-				<Button variant="outline" size="sm" onClick={(e) => handleClick(e, 'list')}>
+				<Button
+					variant="outline"
+					className={isList.activeLayout === 'list' ? 'opacity-40' : ''}
+					size="sm"
+					onClick={(e) => handleClick(e, 'list')}
+				>
 					{<IconList />}
 				</Button>
-				<Button variant="outline" size="sm" onClick={(e) => handleClick(e, 'grid')}>
+				<Button
+					variant="outline"
+					className={isList.activeLayout === 'grid' ? 'opacity-40' : ''}
+					size="sm"
+					onClick={(e) => handleClick(e, 'grid')}
+				>
 					{<IconLayoutGrid />}
 				</Button>
 			</Stack>

--- a/frontend/src/features/dashboard/components/toggleListGrid.tsx
+++ b/frontend/src/features/dashboard/components/toggleListGrid.tsx
@@ -1,6 +1,5 @@
 import { Button, Stack } from '@chakra-ui/react';
 import { IconList, IconLayoutGrid } from '@tabler/icons';
-import React, { useEffect, useState } from 'react';
 
 interface Props {
 	handleClick: (e: React.MouseEvent<HTMLButtonElement>, name: string) => void;

--- a/frontend/src/features/papers/components/Papers.tsx
+++ b/frontend/src/features/papers/components/Papers.tsx
@@ -1,7 +1,11 @@
 import { Paper } from '../types';
 import { usePapers } from '../api/getPapers';
 
-const PapersList = () => {
+interface Props {
+	isList: { activeLayout: string };
+}
+
+const Papers = ({ isList }: Props) => {
 	const { isLoading, error, data: papers } = usePapers();
 
 	if (isLoading) {
@@ -26,7 +30,21 @@ const PapersList = () => {
 		);
 	});
 
-	return <div className="grid gap-4">{displayPapers}</div>;
+	return (
+		<>
+			{papers.length > 0 ? (
+				<div
+					className={
+						isList.activeLayout === 'list' ? 'grid gap-4' : 'grid md:grid-cols-2 lg:grid-cols-3 gap-6'
+					}
+				>
+					{displayPapers}
+				</div>
+			) : (
+				<p>No papers to display.</p>
+			)}
+		</>
+	);
 };
 
-export default PapersList;
+export default Papers;

--- a/frontend/src/features/papers/components/Papers.tsx
+++ b/frontend/src/features/papers/components/Papers.tsx
@@ -21,7 +21,7 @@ const Papers = ({ isList }: Props) => {
 			<div key={index} className="border-b border-slate-200 pb-4">
 				<header>
 					<h5 className="font-bold">{paper.title}</h5>
-					<small className="text-slate-700">{paper.authors.join(', ')}</small>
+					<small className="text-slate-700 dark:text-slate-400">{paper.authors.join(', ')}</small>
 				</header>
 				<div className="content pt-4">
 					<p>{paper.shortAbstract}</p>

--- a/frontend/src/features/tweets/components/Tweets.tsx
+++ b/frontend/src/features/tweets/components/Tweets.tsx
@@ -2,7 +2,11 @@ import { Tweet } from '../types';
 import { useTweets } from '../api/getTweets';
 import dayjs from 'dayjs';
 
-const TweetsList = () => {
+interface Props {
+	isList: { activeLayout: string };
+}
+
+const Tweets = ({ isList }: Props) => {
 	const { isLoading, error, data: tweets } = useTweets();
 
 	if (isLoading) {
@@ -23,7 +27,21 @@ const TweetsList = () => {
 		);
 	});
 
-	return <>{tweets.length > 0 ? <div className="grid gap-4">{displayTweets}</div> : <p>No tweets to display.</p>}</>;
+	return (
+		<>
+			{tweets.length > 0 ? (
+				<div
+					className={
+						isList.activeLayout === 'list' ? 'grid gap-4' : 'grid md:grid-cols-2 lg:grid-cols-3 gap-6'
+					}
+				>
+					{displayTweets}
+				</div>
+			) : (
+				<p>No tweets to display.</p>
+			)}
+		</>
+	);
 };
 
-export default TweetsList;
+export default Tweets;


### PR DESCRIPTION
Closes #62 #63.

Added toggle buttons to switch between list and grid layouts, for papers and tweets.