### PR TITLE
Fix: Paper routes

### DIFF
--- a/backend/src/dev/import-papers.ts
+++ b/backend/src/dev/import-papers.ts
@@ -52,6 +52,7 @@ interface ImportPaper {
 			await insertPaper(paper);
 		} catch (e) {
 			console.log(e);
+			return;
 		}
 	}
 })();

--- a/backend/src/routes/papers/__tests__/papers-route-controller.test.ts
+++ b/backend/src/routes/papers/__tests__/papers-route-controller.test.ts
@@ -50,7 +50,7 @@ describe('paper endpoint get operations', () => {
 	});
 
 	it('GET paper with id should return paper', async () => {
-		const response = await request.get(`${papersEndpoint}/papers/${paper.id}`);
+		const response = await request.get(`${papersEndpoint}/${paper.id}`);
 
 		expect(response.status).toEqual(HttpStatus.OK);
 		expect(response.body).toEqual(paper);
@@ -59,14 +59,18 @@ describe('paper endpoint get operations', () => {
 
 describe('search paper operations', () => {
 	it('GET search paper should return paper matching result', async () => {
-		const response = await request.get(papersEndpoint).query({ search: 'javascript' });
+		const response = await request.get(`${papersEndpoint}/filter`).query({
+			search: 'javascript',
+		});
 
 		expect(response.status).toEqual(HttpStatus.OK);
 		expect(response.body).toEqual([paper]);
 	});
 
 	it('GET search paper should return an empty array as no results match query', async () => {
-		const response = await request.get(`${papersEndpoint}/filter`).query({ search: 'beans' });
+		const response = await request.get(`${papersEndpoint}/filter`).query({
+			search: 'beans',
+		});
 
 		expect(response.status).toEqual(HttpStatus.OK);
 		expect(response.body).toEqual([]);
@@ -80,7 +84,7 @@ describe('paper endpoint update operations', () => {
 			fullAbstract: 'In the before times, C was the language of choice...',
 		};
 
-		const response = await request.patch(`${papersEndpoint}/papers/${paper.id}`).send(payload);
+		const response = await request.patch(`${papersEndpoint}/${paper.id}`).send(payload);
 		const result: Paper = response.body;
 
 		expect(response.status).toEqual(HttpStatus.OK);
@@ -92,7 +96,7 @@ describe('paper endpoint update operations', () => {
 	});
 
 	it('GET paper with id should return updated paper', async () => {
-		const response = await request.get(`${papersEndpoint}/papers/${paper.id}`);
+		const response = await request.get(`${papersEndpoint}/${paper.id}`);
 
 		expect(response.status).toEqual(HttpStatus.OK);
 		expect(response.body).toEqual(paper);
@@ -101,14 +105,14 @@ describe('paper endpoint update operations', () => {
 
 describe('paper endpoint delete operations', () => {
 	it('DELETE paper with id should return updated paper', async () => {
-		const response = await request.delete(`${papersEndpoint}/papers/${paper.id}`);
+		const response = await request.delete(`${papersEndpoint}/${paper.id}`);
 
 		expect(response.status).toEqual(HttpStatus.OK);
 	});
 
 	it('DELETE/GET deleted paper with id should return not found error', async () => {
-		const deleteResponse = await request.delete(`${papersEndpoint}/papers/${paper.id}`);
-		const getResponse = await request.get(`${papersEndpoint}/papers/${paper.id}`);
+		const deleteResponse = await request.delete(`${papersEndpoint}/${paper.id}`);
+		const getResponse = await request.get(`${papersEndpoint}/${paper.id}`);
 
 		expect(deleteResponse.status).toEqual(HttpStatus.NOT_FOUND);
 		expect(getResponse.status).toEqual(HttpStatus.NOT_FOUND);

--- a/backend/src/routes/papers/papers-controller.ts
+++ b/backend/src/routes/papers/papers-controller.ts
@@ -1,7 +1,7 @@
 import { ParameterizedContext } from 'koa';
 import HttpStatus from 'http-status';
 import { deletePaper, getPaper, getPapers, getSearchedPapers, updatePaper, UpdatePaperType } from './papers-model';
-import { PaperSearch, PaperSearchDB } from './papers';
+import { PaperSearchDB } from './papers';
 import { ServerError } from '../types';
 import { handleServerError } from '../util';
 
@@ -56,10 +56,13 @@ export const removePaper = async (ctx: ParameterizedContext): Promise<void> => {
 	ctx.status = HttpStatus.OK;
 };
 
-export const searchedPapers = async (ctx: ParameterizedContext): Promise<void> => {
-	const obj: PaperSearch = { ...ctx.request.query };
+interface PaperSearch {
+	search?: string;
+	source?: string;
+}
 
-	const { search, source } = obj;
+export const searchedPapers = async (ctx: ParameterizedContext): Promise<void> => {
+	const { search, source }: PaperSearch = ctx.request.query;
 	const queryForDb: PaperSearchDB = { title: search, source };
 
 	const papers = await getSearchedPapers(queryForDb);

--- a/backend/src/routes/papers/papers-model.ts
+++ b/backend/src/routes/papers/papers-model.ts
@@ -37,8 +37,6 @@ export const getPaper = async (paperId: number): Promise<Paper | ServerError> =>
 
 export async function getSearchedPapers(params: PaperSearchDB): Promise<Papers> {
 	try {
-		console.log(params);
-		console.log(params.title);
 		return await prisma.paper.findMany({
 			where: {
 				title: {

--- a/backend/src/routes/papers/papers-model.ts
+++ b/backend/src/routes/papers/papers-model.ts
@@ -29,26 +29,25 @@ export const getPaper = async (paperId: number): Promise<Paper | ServerError> =>
 		}
 		return new ServerError(HttpStatus.NOT_FOUND, `Paper with ID ${paperId} not found.`);
 	} catch (e) {
+		console.log(e);
 		console.log(logToFile(e));
 		return new ServerError(HttpStatus.INTERNAL_SERVER_ERROR, 'Unable to get tweet due to server problem.');
 	}
 };
 
-export async function getSearchedPapers(params: PaperSearchDB): Promise<Papers | []> {
+export async function getSearchedPapers(params: PaperSearchDB): Promise<Papers> {
 	try {
+		console.log(params);
+		console.log(params.title);
 		return await prisma.paper.findMany({
 			where: {
-				OR: [
-					{
-						title: {
-							contains: params.title,
-							mode: 'insensitive',
-						},
-						source: {
-							equals: params.source,
-						},
-					},
-				],
+				title: {
+					contains: params.title,
+					mode: 'insensitive',
+				},
+				source: {
+					equals: params.source,
+				},
 			},
 		});
 	} catch (e) {

--- a/backend/src/routes/papers/papers.d.ts
+++ b/backend/src/routes/papers/papers.d.ts
@@ -17,11 +17,6 @@ export interface Paper {
 	scrapeDate?: Date | string;
 }
 
-export interface PaperSearch {
-	search?: string;
-	source?: string;
-}
-
 export interface PaperSearchDB {
 	title?: string;
 	source?: string;

--- a/backend/src/routes/papers/papers.route.ts
+++ b/backend/src/routes/papers/papers.route.ts
@@ -5,11 +5,20 @@ import { paper, papers, searchedPapers, patchPaper, removePaper } from './papers
 const papersRouter = new Router({ prefix: '/papers' });
 
 /**
+ * Get papers based on filter options
+ * ?search: optional search string
+ * ?source: optional source e.g. acm
+ *
+ * GET /api/papers/filter
+ */
+papersRouter.get('/filter', searchedPapers);
+
+/**
  * Get paper with ID
  *
  * GET: /api/papers/:id
  */
-papersRouter.get('/papers/:id', paper);
+papersRouter.get('/:id', paper);
 
 /**
  * Get all papers
@@ -19,26 +28,17 @@ papersRouter.get('/papers/:id', paper);
 papersRouter.get('/', papers);
 
 /**
- * Get papers based on filter options
- * ?search: optional search string
- * ?source: optional source e.g. acm
- *
- * GET /api/papers/:search?/:source?
- */
-papersRouter.get('/filter/:search?/:source?', searchedPapers);
-
-/**
  * Update paper with ID
  *
  * PATCH: /api/papers/:id
  */
-papersRouter.patch('/papers/:id', koaBody(), patchPaper);
+papersRouter.patch('/:id', koaBody(), patchPaper);
 
 /**
  * Delete paper with ID
  *
  * DELETE: /api/papers/:id
  */
-papersRouter.delete('/papers/:id', removePaper);
+papersRouter.delete('/:id', removePaper);
 
 export default papersRouter;

--- a/frontend/src/features/papers/api/getPapers.ts
+++ b/frontend/src/features/papers/api/getPapers.ts
@@ -17,7 +17,8 @@ export const getFilteredPapers = async (payload: PaperSearch): Promise<Papers> =
 	let searchParams = {};
 	for (const [key, value] of Object.entries(payload)) {
 		if (value) {
-			searchParams = { ...searchParams, [key]: value };
+			// add key/value to search query and remove excess whitespace
+			searchParams = { ...searchParams, [key]: value.trim() };
 		}
 	}
 

--- a/frontend/src/features/papers/components/PaperList.tsx
+++ b/frontend/src/features/papers/components/PaperList.tsx
@@ -13,7 +13,6 @@ const PaperList = ({ papers }: Interface) => {
 		return <p>No papers to display.</p>;
 	}
 
-	console.log(papers);
 	const paperList = papers.map((paper: PaperType) => <Paper key={uuid()} paper={paper} />);
 
 	return (

--- a/frontend/src/features/papers/components/PaperSearch.tsx
+++ b/frontend/src/features/papers/components/PaperSearch.tsx
@@ -16,14 +16,19 @@ const PaperSearch = () => {
 
 	useEffect(() => {
 		const getData = async () => {
-			const filteredPaperData = await getFilteredPapers(searchInput);
+			let filteredPaperData;
+
+			if (searchInput.search !== '' || searchInput.source !== '') {
+				filteredPaperData = await getFilteredPapers(searchInput);
+			} else {
+				filteredPaperData = papers;
+			}
+
 			setResults(filteredPaperData);
 		};
 
-		if (searchInput.search !== '' || searchInput.source !== '') {
-			getData().catch(console.error);
-		}
-	}, [searchInput]);
+		getData().catch(console.error);
+	}, [searchInput, papers]);
 
 	if (isLoading) {
 		return <div>Loading Papers...</div>;


### PR DESCRIPTION
@brandonscott4 found a bug where our paper routes were defined like `/api/papers/papers/` which is an interesting bug.

While fixing this bug I fixed the paper filters not working properly and updated the tests to the "correct" paper routes.